### PR TITLE
Refactor component import to remove Vite-specific globEager dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,24 @@ import PackageJSON from "../package.json"
 import type {App} from 'vue'
 import {GlobalConfig, provideGlobalConfig} from "@/hooks";
 
-const components = import.meta.globEager('@/components/*/index.ts');
+const components = [FilterBar, IconButton, ReadWriteSwitch,SearchBar,SpeedDial,Steps, table,tabs/* ... other components */];
+import FilterBar from '@/components/filter-bar/index';
+import IconButton from '@/components/icon-button/index';
+import ReadWriteSwitch from '@/components/read-write-switch/index';
+import SearchBar from '@/components/search-bar/index';
+import SpeedDial from '@/components/speed-dial/index';
+import Steps from '@/components/steps/index';
+import table from '@/components/table/index';
+import tabs from '@/components/tabs/index';
 
 const install = (app: App, config: GlobalConfig): void => {
-  Object.keys(components).forEach(key => {
-    let component = components[key].default;
-    app.use(component)
-  })
-  provideGlobalConfig(config)
+  components.forEach(component => {
+    if (typeof component === 'object' && 'install' in component) {
+      app.use(component);
+    } else if (typeof component === 'function' && component.name) {
+      app.component(component.name, component);
+    }
+  });  provideGlobalConfig(config)
 }
 
 const plugin = {


### PR DESCRIPTION
## Issue
The original code used `import.meta.globEager()` to dynamically import components, which is a Vite-specific feature not available in browser environments after compilation.

## Solution
i modified the component import process to use explicit imports and a manual component registration approach. This ensures compatibility across different build tools and environments.

## Modified Code

```typescript
import PackageJSON from "../package.json"
import type {App} from 'vue'
import {GlobalConfig, provideGlobalConfig} from "@/hooks"

import FilterBar from '@/components/filter-bar/index'
import IconButton from '@/components/icon-button/index'
import ReadWriteSwitch from '@/components/read-write-switch/index'
import SearchBar from '@/components/search-bar/index'
import SpeedDial from '@/components/speed-dial/index'
import Steps from '@/components/steps/index'
import table from '@/components/table/index'
import tabs from '@/components/tabs/index'

const components = [FilterBar, IconButton, ReadWriteSwitch, SearchBar, SpeedDial, Steps, table, tabs]

const install = (app: App, config: GlobalConfig): void => {
  components.forEach(component => {
    if (typeof component === 'object' && 'install' in component) {
      app.use(component)
    } else if (typeof component === 'function' && component.name) {
      app.component(component.name, component)
    }
  })
  provideGlobalConfig(config)
}

const plugin = {
  name: "Fit2CloudUIPlus",
  version: PackageJSON.version,
  install,
}

export default plugin
